### PR TITLE
Rename TYPO3 extension

### DIFF
--- a/Classes/EventListener/BackendUserLookup.php
+++ b/Classes/EventListener/BackendUserLookup.php
@@ -33,7 +33,7 @@ class BackendUserLookup
         }
 
         $providerId = $event->getProviderId();
-        $extendedProviderConfiguration = $this->extensionConfiguration->get('xima-oauth2-extended', $providerId) ?? [];
+        $extendedProviderConfiguration = $this->extensionConfiguration->get('xima_oauth2_extended', $providerId) ?? [];
         $resolverClass = $extendedProviderConfiguration['resolverClassName'] ?? '';
 
         if (!$resolverClass) {

--- a/Classes/EventListener/FrontendUserLookup.php
+++ b/Classes/EventListener/FrontendUserLookup.php
@@ -29,7 +29,7 @@ class FrontendUserLookup
         }
 
         $providerId = $event->getProviderId();
-        $extendedProviderConfiguration = $this->extensionConfiguration->get('xima-oauth2-extended', $providerId) ?? [];
+        $extendedProviderConfiguration = $this->extensionConfiguration->get('xima_oauth2_extended', $providerId) ?? [];
         $resolverClass = $extendedProviderConfiguration['resolverClassName'] ?? '';
 
         if (!$resolverClass) {

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ To create frontend or backend users from OAuth2 authentication, you can create y
         ]
     ],
 
-    'xima-oauth2-extended' => [
+    'xima_oauth2_extended' => [
         'oauth2_client_providers' => [
             // provider of waldhacker/ext-oauth2-client you want to extend
             'yourProviderId' => [

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
 	},
 	"extra": {
 		"typo3/cms": {
-			"extension-key": "xima-oauth2-extended"
+			"extension-key": "xima_oauth2_extended"
 		}
 	},
 	"autoload": {


### PR DESCRIPTION
Due to convention, the extension key should only include underscores. Rename to `xima_oauth2_extended`