### PR TITLE
Make oauth-extended configuration optional

### DIFF
--- a/Classes/EventListener/BackendUserLookup.php
+++ b/Classes/EventListener/BackendUserLookup.php
@@ -22,8 +22,6 @@ class BackendUserLookup
     }
 
     /**
-     * @throws ExtensionConfigurationPathDoesNotExistException
-     * @throws ExtensionConfigurationExtensionNotConfiguredException
      * @throws IdentityResolverException
      */
     public function __invoke(BackendUserLookupEvent $event): void
@@ -33,9 +31,13 @@ class BackendUserLookup
         }
 
         $providerId = $event->getProviderId();
-        $extendedProviderConfiguration = $this->extensionConfiguration->get('xima_oauth2_extended', $providerId) ?? [];
-        $resolverClass = $extendedProviderConfiguration['resolverClassName'] ?? '';
+        try {
+            $extendedProviderConfiguration = $this->extensionConfiguration->get('xima-oauth2-extended', $providerId) ?? [];
+        } catch (ExtensionConfigurationPathDoesNotExistException|ExtensionConfigurationExtensionNotConfiguredException) {
+            return;
+        }
 
+        $resolverClass = $extendedProviderConfiguration['resolverClassName'] ?? '';
         if (!$resolverClass) {
             return;
         }

--- a/Classes/EventListener/FrontendUserLookup.php
+++ b/Classes/EventListener/FrontendUserLookup.php
@@ -4,6 +4,8 @@ namespace Xima\XimaOauth2Extended\EventListener;
 
 use League\OAuth2\Client\Provider\ResourceOwnerInterface;
 use Psr\Log\LoggerInterface;
+use TYPO3\CMS\Core\Configuration\Exception\ExtensionConfigurationExtensionNotConfiguredException;
+use TYPO3\CMS\Core\Configuration\Exception\ExtensionConfigurationPathDoesNotExistException;
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\Exception\SiteNotFoundException;
 use TYPO3\CMS\Core\Site\Entity\Site;
@@ -29,9 +31,13 @@ class FrontendUserLookup
         }
 
         $providerId = $event->getProviderId();
-        $extendedProviderConfiguration = $this->extensionConfiguration->get('xima_oauth2_extended', $providerId) ?? [];
-        $resolverClass = $extendedProviderConfiguration['resolverClassName'] ?? '';
+        try {
+            $extendedProviderConfiguration = $this->extensionConfiguration->get('xima-oauth2-extended', $providerId) ?? [];
+        } catch (ExtensionConfigurationPathDoesNotExistException|ExtensionConfigurationExtensionNotConfiguredException) {
+            return;
+        }
 
+        $resolverClass = $extendedProviderConfiguration['resolverClassName'] ?? '';
         if (!$resolverClass) {
             return;
         }


### PR DESCRIPTION
This prevents an exception for OAuth logins that do not have an extended configuration.