### PR TITLE
Authentik support

### DIFF
--- a/Classes/ResourceProvider/AuthentikResourceProvider.php
+++ b/Classes/ResourceProvider/AuthentikResourceProvider.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Xima\XimaOauth2Extended\ResourceProvider;
+
+use League\OAuth2\Client\Provider\GenericProvider;
+
+class AuthentikResourceProvider extends GenericProvider
+{
+    use SubResourceOwnerIdTrait;
+
+    use TokenBasedResourceOwnerDetailsTrait;
+}

--- a/Classes/ResourceProvider/MicrosoftResourceProvider.php
+++ b/Classes/ResourceProvider/MicrosoftResourceProvider.php
@@ -3,13 +3,8 @@
 namespace Xima\XimaOauth2Extended\ResourceProvider;
 
 use League\OAuth2\Client\Provider\GenericProvider;
-use League\OAuth2\Client\Provider\GenericResourceOwner;
-use League\OAuth2\Client\Token\AccessToken;
 
 class MicrosoftResourceProvider extends GenericProvider
 {
-    protected function createResourceOwner(array $response, AccessToken $token)
-    {
-        return new GenericResourceOwner($response, 'sub');
-    }
+    use SubResourceOwnerIdTrait;
 }

--- a/Classes/ResourceProvider/SubResourceOwnerIdTrait.php
+++ b/Classes/ResourceProvider/SubResourceOwnerIdTrait.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Xima\XimaOauth2Extended\ResourceProvider;
+
+use League\OAuth2\Client\Provider\GenericResourceOwner;
+use League\OAuth2\Client\Token\AccessToken;
+
+trait SubResourceOwnerIdTrait
+{
+    protected function createResourceOwner(array $response, AccessToken $token): GenericResourceOwner
+    {
+        return new GenericResourceOwner($response, 'sub');
+    }
+}

--- a/Classes/ResourceProvider/TokenBasedResourceOwnerDetailsTrait.php
+++ b/Classes/ResourceProvider/TokenBasedResourceOwnerDetailsTrait.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Xima\XimaOauth2Extended\ResourceProvider;
+
+use League\OAuth2\Client\Token\AccessToken;
+
+trait TokenBasedResourceOwnerDetailsTrait
+{
+    /**
+     * @return string[]
+     */
+    protected function getRequiredOptions(): array
+    {
+        return [
+            'urlAuthorize',
+            'urlAccessToken',
+        ];
+    }
+
+    /**
+     * @param AccessToken $token
+     * @return array
+     */
+    protected function fetchResourceOwnerDetails(AccessToken $token): array
+    {
+        $tokenValues = $token->getValues();
+        return (array)json_decode(base64_decode(str_replace('_', '/', str_replace('-', '+', explode('.', $tokenValues['id_token'])[1]))));
+    }
+}

--- a/Classes/ResourceResolver/AuthentikResourceResolver.php
+++ b/Classes/ResourceResolver/AuthentikResourceResolver.php
@@ -2,7 +2,6 @@
 
 namespace Xima\XimaOauth2Extended\ResourceResolver;
 
-use TYPO3\CMS\Core\Http\RequestFactory;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class AuthentikResourceResolver extends GenericResourceResolver implements ProfileImageResolverInterface

--- a/Classes/ResourceResolver/AuthentikResourceResolver.php
+++ b/Classes/ResourceResolver/AuthentikResourceResolver.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Xima\XimaOauth2Extended\ResourceResolver;
+
+use TYPO3\CMS\Core\Http\RequestFactory;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+class AuthentikResourceResolver extends GenericResourceResolver implements ProfileImageResolverInterface
+{
+    public function updateBackendUser(array &$beUser): void
+    {
+        $remoteUser = $this->getRemoteUser()->toArray();
+
+        if (!$beUser['username'] && $remoteUser['email']) {
+            $beUser['username'] = strtolower($remoteUser['email']);
+        }
+
+        if ($remoteUser['email']) {
+            $beUser['email'] = strtolower($remoteUser['email']);
+        }
+
+        $beUser['disable'] = 0;
+
+        if (!$beUser['realName']) {
+            $beUser['realName'] = $remoteUser['name'];
+        }
+    }
+
+    public function resolveProfileImage(): ?string
+    {
+        $remoteUser = $this->getRemoteUser()->toArray();
+
+        if (!isset($remoteUser['avatar']) || !$remoteUser['avatar']) {
+            return null;
+        }
+
+        $base64Parts = GeneralUtility::trimExplode(',', $remoteUser['avatar']);
+
+        return base64_decode($base64Parts[1]) ?: null;
+    }
+
+    public function updateFrontendUser(array &$feUser): void
+    {
+        $remoteUser = $this->getRemoteUser()->toArray();
+
+        if (!$feUser['username'] && $remoteUser['email']) {
+            $feUser['username'] = strtolower($remoteUser['email']);
+        }
+
+        if ($remoteUser['email']) {
+            $feUser['email'] = strtolower($remoteUser['email']);
+        }
+
+        $feUser['disable'] = 0;
+
+        if (!$feUser['name']) {
+            $feUser['name'] = $remoteUser['name'];
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ for on-the-fly user creation.
 ## New resource provider
 
 * `MicrosoftResourceProvider`
+* `AuthentikResourceProvider`
 
 ## TYPO3 user creation
 
@@ -70,6 +71,7 @@ variations in features.
 |---------------------------|:-------------:|:---------------:|:--------------:|
 | GenericResourceResolver   |       ✅       |       🚫        |       🚫       |
 | MicrosoftResourceResolver |       ✅       |   ✅ (BE only)   |  ✅ (BE only)   |
+| AuthentikResourceResolver |       ✅       |   ✅ (BE only)   |       🚫       |
 | GitlabResourceResolver    |       ✅       |       🚫        |       🚫       |
 
 ## Extended resource resolver options
@@ -94,7 +96,10 @@ The extension provides customizable options to tailor the resolver's behavior:
 
 ## FAQ
 
-### Register Return-URLs
+<details>
+<summary>
+Register Return-URLs
+</summary>
 
 For the backend login the return url looks like this:
 
@@ -103,8 +108,12 @@ https://domain.de/typo3/login?loginProvider=1616569531&oauth2-provider=yourProvi
 ```
 
 Replace `domain.de` and `yourProviderId` with your data!
+</details>
 
-### Login not working
+<details>
+<summary>
+Login not working
+</summary>
 
 Make sure `cookieSameSite` is set to `lax`.
 
@@ -113,7 +122,12 @@ $GLOBALS['TYPO3_CONF_VARS']['BE']['cookieSameSite'] = 'lax';
 $GLOBALS['TYPO3_CONF_VARS']['FE']['cookieSameSite'] = 'lax';
 ```
 
-### Order of login provider
+</details>
+
+<details>
+<summary>
+Order of login provider
+</summary>
 
 To change the order of provider displayed at the `/typo3` login page (OAuth
 login over classic username/password), use the following snippet:
@@ -122,7 +136,12 @@ login over classic username/password), use the following snippet:
 $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['backend']['loginProviders']['1616569531']['sorting'] = 75;
 ```
 
-### Usage in TYPO3v12
+</details>
+
+<details>
+<summary>
+Usage in TYPO3v12
+</summary>
 
 The TYPO3
 extension [waldhacker/ext-oauth2-client](https://github.com/waldhacker/ext-oauth2-client)
@@ -132,14 +151,16 @@ makes the trick. To use it, adjust your `composer.json`:
 
 ```json
 {
-    "repositories": [
-        {
-            "url": "https://github.com/maikschneider/ext-oauth2-client.git",
-            "type": "git"
-        }
-    ],
-    "require": {
-        "waldhacker/typo3-oauth2-client": "dev-feature/v12-compatibility-1"
+  "repositories": [
+    {
+      "url": "https://github.com/maikschneider/ext-oauth2-client.git",
+      "type": "git"
     }
+  ],
+  "require": {
+    "waldhacker/typo3-oauth2-client": "dev-feature/v12-compatibility-1"
+  }
 }
 ```
+
+</details>

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,9 +1,29 @@
 parameters:
 	ignoreErrors:
 		-
+			message: "#^Method Xima\\\\XimaOauth2Extended\\\\ResourceProvider\\\\AuthentikResourceProvider\\:\\:createResourceOwner\\(\\) has parameter \\$response with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: Classes/ResourceProvider/AuthentikResourceProvider.php
+
+		-
+			message: "#^Method Xima\\\\XimaOauth2Extended\\\\ResourceProvider\\\\AuthentikResourceProvider\\:\\:fetchResourceOwnerDetails\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: Classes/ResourceProvider/AuthentikResourceProvider.php
+
+		-
 			message: "#^Method Xima\\\\XimaOauth2Extended\\\\ResourceProvider\\\\MicrosoftResourceProvider\\:\\:createResourceOwner\\(\\) has parameter \\$response with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: Classes/ResourceProvider/MicrosoftResourceProvider.php
+
+		-
+			message: "#^Method Xima\\\\XimaOauth2Extended\\\\ResourceResolver\\\\AuthentikResourceResolver\\:\\:updateBackendUser\\(\\) has parameter \\$beUser with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: Classes/ResourceResolver/AuthentikResourceResolver.php
+
+		-
+			message: "#^Method Xima\\\\XimaOauth2Extended\\\\ResourceResolver\\\\AuthentikResourceResolver\\:\\:updateFrontendUser\\(\\) has parameter \\$feUser with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: Classes/ResourceResolver/AuthentikResourceResolver.php
 
 		-
 			message: "#^Method Xima\\\\XimaOauth2Extended\\\\ResourceResolver\\\\GenericResourceResolver\\:\\:updateBackendUser\\(\\) has parameter \\$beUser with no value type specified in iterable type array\\.$#"


### PR DESCRIPTION
This PR adds a ResourceResolver and ResourceProvider for the Identity Provider [authentik](https://github.com/goauthentik/authentik).

* New `TokenBasedResourceOwnerDetailsTrait`: Omit the Userinfo request by decoding the AccessToken for user data
  * The authentik service needs to be configured to "Include claims in id_token" (see Advanced protocol settings in provider config)
* New `SubResourceOwnerIdTrait`: Some provider do not align with the default `id` offset, but use `sub`
  * MicrosoftResourceProvider now uses this trait as well
* The `AuthentikResourceResolver` implements the `ProfileImageResolverInterface` which assumes the image to be base64-encoded in the `avatar` offset
* No group support yet