### PR TITLE
Add ext_emconf.php

### DIFF
--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -1,0 +1,22 @@
+<?php
+
+$EM_CONF[$_EXTKEY] = [
+    'title' => 'OAuth2 Extended',
+    'description' => 'Provides additional OAuth2 provider + on-the-fly user creation',
+    'category' => 'auth',
+    'author' => 'Maik Schneider',
+    'author_email' => 'maik.schneider@xima.de',
+    'author_company' => 'XIMA Media GmbH',
+    'state' => 'stable',
+    'uploadfolder' => 0,
+    'clearCacheOnLoad' => 1,
+    'version' => '2.0.2',
+    'autoload' => [
+        'psr-4' => ['Xima\\XimaOauth2Extended\\' => 'Classes'],
+    ],
+    'constraints' => [
+        'depends' => [
+            'typo3' => '11.5.99-12.4.99',
+        ],
+    ],
+];


### PR DESCRIPTION
To display the extension in the TYPO3 backend extension module, an `ext_emconf.php` file is needed.