### PR TITLE
Feat: Use PHP8.2 in SCA workflow

### DIFF
--- a/.github/workflows/test-sca.yml
+++ b/.github/workflows/test-sca.yml
@@ -9,4 +9,4 @@ jobs:
     tests:
         uses: maikschneider/reusable-workflows/.github/workflows/sca.yml@main
         with:
-            php-version: 8.1
+            php-version: 8.2


### PR DESCRIPTION
The workflow currently uses 8.1 which conflicts with newer symfony components