### PR TITLE
fix: abort in case fe_users do not have slug field

### DIFF
--- a/Classes/UserFactory/FrontendUserFactory.php
+++ b/Classes/UserFactory/FrontendUserFactory.php
@@ -112,6 +112,11 @@ class FrontendUserFactory
 
     protected function updateFrontendUserSlug(&$userRecord): void
     {
+        // abort in case no slug field is defined
+        if (!isset($GLOBALS['TCA']['fe_users']['columns']['slug'])) {
+            return;
+        }
+
         // init SlugHelper for this table
         $fieldConfig = $GLOBALS['TCA']['fe_users']['columns']['slug']['config'];
         /** @var SlugHelper $slugHelper */


### PR DESCRIPTION
Prevent undefined array key error in case `fe_users` do not have a `slug` column defined.

fixes #25 