### PR TITLE
fix: default frontend user group setting

### DIFF
--- a/Classes/UserFactory/FrontendUserFactory.php
+++ b/Classes/UserFactory/FrontendUserFactory.php
@@ -239,7 +239,7 @@ class FrontendUserFactory
     ])] public function createBasicFrontendUser(int $targetPid): array
     {
         $saltingInstance = GeneralUtility::makeInstance(PasswordHashFactory::class)->getDefaultHashInstance('FE');
-        $defaultUserGroup = $this->extendedProviderConfiguration['defaultFrontendUsergroup'] ?? '';
+        $defaultUserGroup = $this->extendedProviderConfiguration[$this->providerId]['defaultFrontendUsergroup'] ?? '';
 
         return [
             'pid' => $targetPid,


### PR DESCRIPTION
The setting `defaultFrontendUsergroup` was not accessed correctly.

(cherry picked from commit 6a273731e1c23a29acea1741bda9aa322d8a75ac)