### PR TITLE
fix: preserve legitimate user groups during updates

### DIFF
--- a/Classes/UserFactory/BackendUserFactory.php
+++ b/Classes/UserFactory/BackendUserFactory.php
@@ -115,7 +115,7 @@ class BackendUserFactory extends AbstractUserFactory
         $groupIdResults = $qb->select('g.uid')
             ->distinct()
             ->from('be_groups', 'g')
-            ->leftJoin('g', 'be_users', 'u', $qb->expr()->inSet('g.uid', $qb->quoteIdentifier('u.usergroup')))
+            ->leftJoin('g', 'be_users', 'u', $qb->expr()->inSet('u.usergroup', $qb->quoteIdentifier('g.uid')))
             ->where(
                 $qb->expr()->or(
                     $qb->expr()->in('g.oauth2_id', $qb->quoteArrayBasedValueListToStringList($groupIds)),


### PR DESCRIPTION
Corrected the user group join condition in BackendUserFactory to prevent the unintended removal of legitimate groups.