### PR TITLE
Drop field `cruser_id` in provider creation

### DIFF
--- a/Classes/UserFactory/BackendUserFactory.php
+++ b/Classes/UserFactory/BackendUserFactory.php
@@ -350,7 +350,6 @@ class BackendUserFactory extends AbstractUserFactory
                 'provider' => $this->providerId,
                 'crdate' => time(),
                 'tstamp' => time(),
-                'cruser_id' => (int)$userRecord['uid'],
                 'parentid' => (int)$userRecord['uid'],
             ])
             ->executeStatement();

--- a/Classes/UserFactory/FrontendUserFactory.php
+++ b/Classes/UserFactory/FrontendUserFactory.php
@@ -159,7 +159,6 @@ class FrontendUserFactory
                 'provider' => $this->providerId,
                 'crdate' => time(),
                 'tstamp' => time(),
-                'cruser_id' => (int)$userRecord['uid'],
                 'parentid' => (int)$userRecord['uid'],
             ])
             ->executeStatement();


### PR DESCRIPTION
In the latest version of [co-stack/typo3-oauth2-client](https://gitlab.com/co-stack.com/co-stack.com/typo3-extensions/typo3-oauth2-client/-/commit/b713e680157940d9f6d16d2ea3fa0959bab4af74) the `cruser_id` field was removed from the `tx_oauth2_feuser_provider_configuration` table.

This PR updates our code accordingly by removing the assignment of the now-nonexistent `cruser_id` field during record insertion.