### PR TITLE
Skip sudo mode: Remove check for user creation

### DIFF
--- a/Classes/EventListener/SkipSudoModeRequirement.php
+++ b/Classes/EventListener/SkipSudoModeRequirement.php
@@ -29,11 +29,6 @@ class SkipSudoModeRequirement
             return;
         }
 
-        // User has an oauth2 configuration with enabled user creation
-        if (!$this->currentUserHasOauthProviderWithCreation()) {
-            return;
-        }
-
         // Users can always bypass sudo mode if changing their own password
         $subjects = $event->getClaim()->subjects;
         if (isset($subjects[0]) && str_starts_with($subjects[0]->getSubject(), 'be_users.password.')) {
@@ -50,37 +45,6 @@ class SkipSudoModeRequirement
     private function getCurrentUser(): BackendUserAuthentication
     {
         return $GLOBALS['BE_USER'];
-    }
-
-    private function currentUserHasOauthProviderWithCreation(): bool
-    {
-        $allProviderConfigs = $this->extensionConfiguration->get('xima_oauth2_extended', 'oauth2_client_providers', []);
-        $providerWithCreation = array_keys(array_filter($allProviderConfigs, static function ($config) {
-            return isset($config['createBackendUser']) && $config['createBackendUser'] === true;
-        }));
-
-        if (empty($providerWithCreation)) {
-            return false;
-        }
-
-        $userUid = $this->getCurrentUser()->getUserId();
-
-        $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable('tx_oauth2_beuser_provider_configuration');
-        $userProvider = $queryBuilder->count('uid')
-            ->from('tx_oauth2_beuser_provider_configuration')
-            ->where(
-                $queryBuilder->expr()->eq('parentid', $queryBuilder->createNamedParameter($userUid, Connection::PARAM_INT))
-            )
-            ->andWhere(
-                $queryBuilder->expr()->in(
-                    'provider',
-                    $queryBuilder->createNamedParameter($providerWithCreation, Connection::PARAM_STR_ARRAY)
-                )
-            )
-            ->executeQuery()
-            ->fetchOne();
-
-        return (bool)$userProvider;
     }
 
     private function currentUserIsAdmin(): bool


### PR DESCRIPTION
With this PR the sudo mode becomes skipped more often. It is no longer checked if the current user has an oauth2 configuration with enabled on-the-fly user creation. This is because users can have manually created accounts without password but oauth2.